### PR TITLE
(SIMP-5477) Fix typo in OEL box names

### DIFF
--- a/spec/acceptance/nodesets/oel-combined-x64.yml
+++ b/spec/acceptance/nodesets/oel-combined-x64.yml
@@ -12,7 +12,7 @@ HOSTS:
       - master
       - client
     platform:   el-7-x86_64
-    box:        onxypoint/oel-7-x86_64
+    box:        onyxpoint/oel-7-x86_64
     hypervisor: <%= hypervisor %>
     yum_repos:
       epel:
@@ -24,7 +24,7 @@ HOSTS:
     roles:
       - client
     platform:   el-6-x86_64
-    box:        onxypoint/oel-6-x86_64
+    box:        onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
     yum_repos:
       epel:


### PR DESCRIPTION
Although no acceptance tests exist for this project, corrected a typo that
would be a problem when acceptance tests are added.

SIMP 5477 #comment update to onyxpoint OEL nodes pupmod-simp-simp_banners