### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,6 @@
 ---
 fixtures:
   repositories:
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
+    stdlib: https://github.com/simp/puppetlabs-stdlib
   symlinks:
     simp_banners: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,6 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Wed Jun 27 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.0
 - First release

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ systems, Puppet versions, and module dependencies.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_banners",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "simp",
   "summary": "Common banners collected for use in puppet modules",
   "license": "Apache-2.0",
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-simp_banners