### PR TITLE
[puppetsync] Re-assert the refreshed pupmod baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ dist
 /pkg
 # Read everything in fixtures
 /spec/fixtures/*
-# Un-ignore hieradata
+# Un-ignore hieradata. The directory itself must be re-included first, otherwise
+# `/spec/fixtures/*` above excludes it and git cannot re-include files within it.
+!/spec/fixtures/hieradata/
 !/spec/fixtures/hieradata/*
 # Except this one, which is auto-generated
 /spec/fixtures/hieradata/hiera.yaml
@@ -25,6 +27,7 @@ dist
 /log
 /doc
 /Gemfile.lock
+/Gemfile.local
 
 ## AI coding assistant-specific configuration
 ## The standard is AGENTS.md

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -13,3 +13,6 @@
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check
+# puppet-lint-strict_indent-check 5.0.0 crashes on some valid manifests
+# (remove when the plugin is fixed upstream)
+--no-strict_indent-check

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,18 +25,18 @@ if ENV['PUPPET_DEBUG']
 end
 
 default_hiera_config = <<~HIERA_CONFIG
----
-version: 5
-hierarchy:
-  - name: Custom Test Hiera
-    path: "%{custom_hiera}.yaml"
-  - name: "%{module_name}"
-    path: "%{module_name}.yaml"
-  - name: Common
-    path: default.yaml
-defaults:
-  data_hash: yaml_data
-  datadir: "stub"
+  ---
+  version: 5
+  hierarchy:
+    - name: Custom Test Hiera
+      path: "%{custom_hiera}.yaml"
+    - name: "%{module_name}"
+      path: "%{module_name}.yaml"
+    - name: Common
+      path: default.yaml
+  defaults:
+    data_hash: yaml_data
+    datadir: "stub"
 HIERA_CONFIG
 
 # This can be used from inside your spec tests to set the testable environment.
@@ -89,8 +89,8 @@ RSpec.configure do |c|
     production: {
       # :fqdn           => 'production.rspec.test.localdomain',
       path: '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      concat_basedir: '/tmp'
-    }
+      concat_basedir: '/tmp',
+    },
   }
 
   c.mock_framework = :rspec


### PR DESCRIPTION
This patch re-asserts the puppetsync-managed baseline files after
reconciling the templates with the deployed fleet (the templates
now describe the OpenVox-era reality — voxpupuli-test spec_helper,
current dotfiles):

- spec/spec_helper.rb: normalized to the fleet-majority variant
- .puppet-lint.rc: disable the strict_indent check fleet-wide
  (puppet-lint-strict_indent-check 5.0.0 crashes on some valid
  manifests; 16 repos already carried this workaround)
- .gitignore/.pdkignore/.gitattributes/.rspec: majority variants

Gemfiles and workflow files are bootstrap-strategy and are not
touched by this sync (Renovate manages their versions in place).